### PR TITLE
Change array of symbols creation syntax to support Ruby 1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,29 @@
+# 1.4.1
+* Change array creation syntax to support Ruby 1.9
+
 # 1.4.0
-Adds '_with_data' to the simple logger so we can display data in the
-terminal
-Adds 'respond_to?' to the multilogger so users can check capabilities of
-the loggers
+* Adds '_with_data' to the simple logger so we can display data in the terminal
+* Adds 'respond_to?' to the multilogger so users can check capabilities of the loggers
 
 # 1.3.1
-Loggers provide an inspect method to avoid being too noisy on outputs
+* Loggers provide an inspect method to avoid being too noisy on outputs
 
 # 1.3.0
-Time in the JSON output specifies microseconds.
-Using 'Z' to specify the UTC timezone instead of +0000 as per ISO 8601.
-Debug and Info messages use the default foreground color of the terminal.
+* Time in the JSON output specifies microseconds.
+* Using 'Z' to specify the UTC timezone instead of +0000 as per ISO 8601.
+* Debug and Info messages use the default foreground color of the terminal.
 
 # 1.2.1
-If a file does not exist, it will create it on behalf of the application
+* If a file does not exist, it will create it on behalf of the application
 
 # 1.2
-Added a silence_logger method to the logger. For compatibility with
-activerecord-session and maybe other gems.
+* Added a silence_logger method to the logger. For compatibility with activerecord-session and maybe other gems.
+
 # 1.1.1
-Avoid syntax errors in rubies < 2.3
+* Avoid syntax errors in rubies < 2.3
 
 # 1.1.0
-Added an 'add' method to the logger so it is compatible with the Logger
-provided by Ruby's standard library
+* Added an 'add' method to the logger so it is compatible with the Logger provided by Ruby's standard library
 
 # 1.0.0
-Initial release
+* Initial release

--- a/lib/lorekeeper/fast_logger.rb
+++ b/lib/lorekeeper/fast_logger.rb
@@ -21,7 +21,7 @@ module Lorekeeper
       @file = file # We only keep this so we can inspect where we are sending the logs
     end
 
-    LOGGING_METHODS = %i(debug info warn error fatal)
+    LOGGING_METHODS = [:debug, :info, :warn, :error, :fatal]
     METHOD_SEVERITY_MAP = { debug: DEBUG, info: INFO, warn: WARN, error: ERROR, fatal: FATAL }
 
     # We define the behaviour of all the usual logging methods

--- a/lib/lorekeeper/version.rb
+++ b/lib/lorekeeper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 # The comment above will make all strings in a current file frozen
 module Lorekeeper
-  VERSION = '1.4.0'.freeze
+  VERSION = '1.4.1'.freeze
 end


### PR DESCRIPTION
- `%i(...)` → `[:a, :b, ...]`
- Updated changelog to improve readability

@JordiPolo 