### PR TITLE
Update OJ version used, bump gem version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ rvm:
   - 2.1.8
   - 2.2.4
   - 2.3.0
+  - 2.4.0
 script: 'bundle exec rspec'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.6.1
+* Update reference to OJ gem to support Ruby 2.4
+
 # 1.6.0
 * Adds 'exception' to simple logger to unify APIs
 

--- a/lib/lorekeeper/version.rb
+++ b/lib/lorekeeper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 # The comment above will make all strings in a current file frozen
 module Lorekeeper
-  VERSION = '1.6.0'.freeze
+  VERSION = '1.6.1'.freeze
 end

--- a/lorekeeper.gemspec
+++ b/lorekeeper.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'oj', '~> 2.14'
+  spec.add_dependency 'oj', '~> 2.18'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
I encountered problems when using Oj version 2.14 on Ruby 2.4, so I upgraded lorekeeper to use the latest Oj 2.18. I tested this on Ruby versions from 1.9 to 2.4, and the tests passed on all of them.