### PR TITLE
Update oj gem to resolve segmentation fault issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.6.2
+* Update oj gem to resolve segmentation fault issue
+
 # 1.6.1
 * Update reference to OJ gem to support Ruby 2.4
 

--- a/lib/lorekeeper/version.rb
+++ b/lib/lorekeeper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 # The comment above will make all strings in a current file frozen
 module Lorekeeper
-  VERSION = '1.6.1'.freeze
+  VERSION = '1.6.2'.freeze
 end

--- a/lorekeeper.gemspec
+++ b/lorekeeper.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'oj', '~> 2.18'
+  spec.add_dependency 'oj', '>= 3.3.1', '< 4.0'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
In response to https://github.com/JordiPolo/lorekeeper/issues/5, the issue has been resolved by the maintainer of the 'oj' gem (See: https://github.com/ohler55/oj/issues/404)

@JordiPolo @jfeltesse-mdsol @ykitamura-mdsol 