### PR TITLE
ensure `data` is not nil when logging wrong #exception usage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.7.1
+* Ensure `data` is not nil when logging wrong #exception usage
+
 # 1.7.0
 * Add the `level` property to the JSON Logger output
 

--- a/lib/lorekeeper/json_logger.rb
+++ b/lib/lorekeeper/json_logger.rb
@@ -79,7 +79,7 @@ module Lorekeeper
       else
         log_data(METHOD_SEVERITY_MAP[:warn], 'Logger exception called without exception class.')
         message = "#{exception.class}: #{exception.inspect} #{custom_message}"
-        with_extra_fields('data' => custom_data) { log_data(log_level, message) }
+        with_extra_fields('data' => (custom_data || {})) { log_data(log_level, message) }
       end
     end
 

--- a/lib/lorekeeper/version.rb
+++ b/lib/lorekeeper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lorekeeper
-  VERSION = '1.7.0'
+  VERSION = '1.7.1'
 end

--- a/spec/lib/lorekeeper/json_logger_spec.rb
+++ b/spec/lib/lorekeeper/json_logger_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Lorekeeper do
               },
               {
                 'level' => 'error',
-                'data' => nil,
+                'data' => {},
                 'message' => "String: #{message.inspect} ",
                 'timestamp' => time_string
               }


### PR DESCRIPTION
Overlooked this one in my previous PR.

Before this was using the `error_with_data` method which, if provided `nil` for data, would convert this to an empty hash.
After I switched to "manually" log (so the custom level is used) I forgot to do this conversion. The specs were actually covering that part but there were so many changes I went with whatever it gave me without thinking twice.

@JordiPolo 