### PR TITLE
Add a second parameter to respond_to in Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ rvm:
   - 2.1.10
   - 2.2.10
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
 
 before_install:
   - gem install rubygems-update -v 2.7.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.1.10
-  - 2.2.10
   - 2.3.8
   - 2.4.6
   - 2.5.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.7.2
+* Add a second parameter to respond_to? to avoid Ruby 2.6 warnings
+
 # 1.7.1
 * Ensure `data` is not nil when logging wrong #exception usage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.7.2
 * Add a second parameter to respond_to? to avoid Ruby 2.6 warnings
+* Drop support for unsupported Ruby 2.1 and Ruby 2.2
 
 # 1.7.1
 * Ensure `data` is not nil when logging wrong #exception usage

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,4 @@
 source 'https://rubygems.org'
 
-group :development do
-  gem 'mutant-rspec', '~> 0.8'
-end
-
 # Specify your gem's dependencies in lorekeeper.gemspec
 gemspec

--- a/lib/lorekeeper/multi_logger.rb
+++ b/lib/lorekeeper/multi_logger.rb
@@ -16,9 +16,15 @@ module Lorekeeper
       "Lorekeeper multilogger, loggers: #{@loggers.map(&:inspect)}"
     end
 
+if RUBY_VERSION > "2.6"
+    def respond_to?(method, all_included = false)
+      @loggers.all? { |logger| logger.respond_to?(method, all_included) }
+    end
+else
     def respond_to?(method)
       @loggers.all? { |logger| logger.respond_to?(method) }
     end
+end
 
     def method_missing(method, *args, &block)
       result = @loggers.map do |logger|

--- a/lib/lorekeeper/version.rb
+++ b/lib/lorekeeper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lorekeeper
-  VERSION = '1.7.1'
+  VERSION = '1.7.2'
 end

--- a/lorekeeper.gemspec
+++ b/lorekeeper.gemspec
@@ -26,10 +26,11 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '>= 1.16', '< 3.0'
   spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'rspec', '~> 3.4'
+  spec.add_development_dependency 'rspec', '~> 3.8'
   spec.add_development_dependency 'benchmark-ips', '~> 2.3'
   spec.add_development_dependency 'timecop', '~> 0.8'
-  spec.add_development_dependency 'byebug', '~> 8.0'
+  spec.add_development_dependency 'byebug', '~> 11.0'
   spec.add_development_dependency 'rbtrace', '~> 0.4'
   spec.add_development_dependency 'simplecov', '~> 0.16'
+  spec.add_development_dependency 'mutant-rspec', '~> 0.8'
 end

--- a/lorekeeper.gemspec
+++ b/lorekeeper.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.1.0'
+  spec.required_ruby_version = '>= 2.3.0'
 
   spec.add_dependency 'oj', '>= 3.4', '< 4.0'
 


### PR DESCRIPTION
Background:
Ruby 2.6 adds a second param to `respond_to?` which causes ruby warnings when overriding it.
Those warnings seems to be happening inside the C world of Ruby interpreter and can't become exceptions AFAIK so I do not know how to rspec this.

I'm not sure either if this is the best approach for this kind of issues. Please let me know.
@nagarwal-mdsol
