### PR TITLE
Adds named parameters to exception method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.8.0
+* Allow to use named parameters in the .exception method
+
 # 1.7.2
 * Add a second parameter to respond_to? to avoid Ruby 2.6 warnings
 * Drop support for unsupported Ruby 2.1 and Ruby 2.2

--- a/README.md
+++ b/README.md
@@ -169,6 +169,24 @@ Will output:
 }
 ```
 
+Alternatively you can use named parameters:
+
+
+```ruby
+rescue => e
+  logger.exception(e, message: "custom msg!", data: { some: { data: 123 } }, level: :warn)
+end
+```
+
+This is specially useful when there is no custom message or data:
+
+```ruby
+rescue => e
+  logger.exception(e, level: :warn)
+end
+```
+
+
 
 ## License
 

--- a/Rakefile
+++ b/Rakefile
@@ -50,10 +50,10 @@ task :benchmark do
   simple_log = create_simple_logger
 
   Benchmark.ips do |bm|
-    bm.report('short content') { log.error(contents) }
-    bm.report('Logger short content') { simple_log.info(contents) }
-    bm.report('long content') { log.info(long_contents) }
-    bm.report('Logger long content') { simple_log.info(long_contents) }
+    bm.report('JSON short content') { log.debug(contents) }
+    bm.report('Logger short content') { simple_log.debug(contents) }
+    bm.report('JSON long content') { log.debug(long_contents) }
+    bm.report('Logger long content') { simple_log.debug(long_contents) }
     bm.compare!
   end
 

--- a/lib/lorekeeper/json_logger.rb
+++ b/lib/lorekeeper/json_logger.rb
@@ -60,10 +60,9 @@ module Lorekeeper
       end
     end
 
-
     # @param exception: instance of a class inheriting from Exception
-    # We will output backtrace twice. Once inside the stack so it can be parsed by software
-    # And the other inside the message so it is readable to humans
+    # By default message comes from exception.message
+    # Optional and named parameters to overwrite message, level and add data
     def exception(exception, custom_message = nil, custom_data = nil, custom_level = :error,
                              message: nil, data: nil, level: nil) # Backwards compatible named params
 
@@ -118,11 +117,12 @@ module Lorekeeper
     end
 
     def log_data(severity, message)
+      current_state = state # Accessing state is slow. Do it only once per call.
       # merging is slow, we do not want to merge with empty hash if possible
-      fields_to_log = if state[:extra_fields].empty?
-        state[:base_fields]
+      fields_to_log = if current_state[:extra_fields].empty?
+        current_state[:base_fields]
       else
-        state[:base_fields].merge(state[:extra_fields])
+        current_state[:base_fields].merge(current_state[:extra_fields])
       end
 
       fields_to_log[MESSAGE] = message

--- a/lib/lorekeeper/version.rb
+++ b/lib/lorekeeper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lorekeeper
-  VERSION = '1.7.2'
+  VERSION = '1.8.0'
 end

--- a/spec/lib/lorekeeper/json_logger_spec.rb
+++ b/spec/lib/lorekeeper/json_logger_spec.rb
@@ -120,9 +120,9 @@ RSpec.describe Lorekeeper do
             base_message.merge(
               'exception' => "StandardError: #{exception_msg}",
               'message' => exception_msg,
-              'stack' => stack
+              'stack' => stack,
+              'level' => 'info'
             )
-            .merge({ 'level' => 'info' })
           end
 
           it 'Logs the exception with the level in the parameters' do
@@ -201,7 +201,7 @@ RSpec.describe Lorekeeper do
           end
 
           it 'Logs the exception message' do
-            logger.exception(message, message: 'second part not good', data: {'planet' => 'hyperion' })
+            logger.exception(message, message: 'second part not good', data: { 'planet' => 'hyperion' })
             expect(io.received_messages).to eq(base_message)
           end
         end
@@ -304,7 +304,7 @@ RSpec.describe Lorekeeper do
           it_behaves_like 'Logging methods'
 
           it 'removes information from the local thread' do
-            expect(Thread.current[Lorekeeper::JSONLogger::THREAD_KEY]).to eq(nil)
+            expect(Thread.current[Lorekeeper::JSONLogger::THREAD_KEY]).to be_nil
           end
         end
 


### PR DESCRIPTION
I see people want to change the level of the exception log but 
`logger.exception(e, nil, nil, :warn)` looks really obscure

What do you think about this interface instead?

@jfeltesse-mdsol  @ssteeg-mdsol  @ykitamura-mdsol 
