### PR TITLE
Removes newrelic instrumentation from stacktrace output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.9.0
+* Remove Newrelic instrumentation information from stacktrace output
+
 # 1.8.0
 * Allow to use named parameters in the .exception method
 

--- a/lib/lorekeeper/json_logger.rb
+++ b/lib/lorekeeper/json_logger.rb
@@ -100,7 +100,7 @@ module Lorekeeper
     # Hardcoring newrelic now here. In the future if this list grows, we may make it configurable.
     def clean_backtrace(backtrace)
       backtrace.reject do |line|
-        BLACKLISTED_FINGERPRINTS.any? { |fingerprint| line.include?(fingerprint) }
+        line.include?(BLACKLISTED_FINGERPRINT)
       end
     end
 
@@ -112,7 +112,7 @@ module Lorekeeper
     EXCEPTION = 'exception'
     STACK = 'stack'
     DATA = 'data'
-    BLACKLISTED_FINGERPRINTS = ['/newrelic_rpm-']
+    BLACKLISTED_FINGERPRINT = '/newrelic_rpm-'
 
     def with_extra_fields(fields)
       state[:extra_fields] = fields

--- a/lib/lorekeeper/json_logger.rb
+++ b/lib/lorekeeper/json_logger.rb
@@ -73,7 +73,7 @@ module Lorekeeper
       log_level = METHOD_SEVERITY_MAP[param_level] || ERROR
 
       if exception.is_a?(Exception)
-        backtrace = clean_backtrace!(exception.backtrace || [])
+        backtrace = clean_backtrace(exception.backtrace || [])
         exception_fields = {
           EXCEPTION => "#{exception.class}: #{exception.message}",
           STACK => backtrace
@@ -98,9 +98,8 @@ module Lorekeeper
     # Some instrumentation libraries pollute the stacktrace and create a large output which may
     # cause problems with certain logging backends.
     # Hardcoring newrelic now here. In the future if this list grows, we may make it configurable.
-    def clean_backtrace!(backtrace)
-      backtrace.reject!{ |line| line.include?("newrelic_rpm") }
-      backtrace
+    def clean_backtrace(backtrace)
+      backtrace.reject{ |line| line.include?("/newrelic_rpm-") }
     end
 
     THREAD_KEY = 'lorekeeper_jsonlogger_key' # Shared by all threads but unique by thread

--- a/lib/lorekeeper/json_logger.rb
+++ b/lib/lorekeeper/json_logger.rb
@@ -73,7 +73,7 @@ module Lorekeeper
       log_level = METHOD_SEVERITY_MAP[param_level] || ERROR
 
       if exception.is_a?(Exception)
-        backtrace = exception.backtrace || []
+        backtrace = clean_backtrace!(exception.backtrace || [])
         exception_fields = {
           EXCEPTION => "#{exception.class}: #{exception.message}",
           STACK => backtrace
@@ -94,6 +94,14 @@ module Lorekeeper
     end
 
     private
+
+    # Some instrumentation libraries pollute the stacktrace and create a large output which may
+    # cause problems with certain logging backends.
+    # Hardcoring newrelic now here. In the future if this list grows, we may make it configurable.
+    def clean_backtrace!(backtrace)
+      backtrace.reject!{ |line| line.include?("newrelic_rpm") }
+      backtrace
+    end
 
     THREAD_KEY = 'lorekeeper_jsonlogger_key' # Shared by all threads but unique by thread
     LEVEL = 'level'

--- a/lib/lorekeeper/json_logger.rb
+++ b/lib/lorekeeper/json_logger.rb
@@ -99,7 +99,9 @@ module Lorekeeper
     # cause problems with certain logging backends.
     # Hardcoring newrelic now here. In the future if this list grows, we may make it configurable.
     def clean_backtrace(backtrace)
-      backtrace.reject{ |line| line.include?("/newrelic_rpm-") }
+      backtrace.reject do |line|
+        BLACKLISTED_FINGERPRINTS.any? { |fingerprint| line.include?(fingerprint) }
+      end
     end
 
     THREAD_KEY = 'lorekeeper_jsonlogger_key' # Shared by all threads but unique by thread
@@ -110,6 +112,7 @@ module Lorekeeper
     EXCEPTION = 'exception'
     STACK = 'stack'
     DATA = 'data'
+    BLACKLISTED_FINGERPRINTS = ['/newrelic_rpm-']
 
     def with_extra_fields(fields)
       state[:extra_fields] = fields

--- a/lib/lorekeeper/version.rb
+++ b/lib/lorekeeper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lorekeeper
-  VERSION = '1.8.0'
+  VERSION = '1.9.0'
 end

--- a/spec/lib/lorekeeper/json_logger_spec.rb
+++ b/spec/lib/lorekeeper/json_logger_spec.rb
@@ -113,6 +113,28 @@ RSpec.describe Lorekeeper do
               base_message.merge('level' => 'info')
             ])
           end
+
+          it 'Does not log Newrelic instrumentation information' do
+            new_backtrace = [
+              "2.5.0/gems/newrelic_rpm-5.7.0.350/lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'",
+              "2.5.0/gems/actionpack-4.2.11/lib/action_dispatch/middleware/cookies.rb:560:in `call'",
+              "2.5.0/gems/newrelic_rpm-5.7.0.350/lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'",
+              "2.5.0/gems/actionpack-4.2.11/lib/action_dispatch/middleware/callbacks.rb:29:in `block in call'",
+              "2.5.0/gems/actionpack-4.2.11/lib/action_dispatch/middleware/callbacks.rb:27:in `call'",
+              "2.5.0/gems/newrelic_rpm-5.7.0.350/lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'"
+            ]
+            exception.set_backtrace(new_backtrace)
+            logger.exception(exception)
+
+            no_newrelic_backtrace = [
+              "2.5.0/gems/actionpack-4.2.11/lib/action_dispatch/middleware/cookies.rb:560:in `call'",
+              "2.5.0/gems/actionpack-4.2.11/lib/action_dispatch/middleware/callbacks.rb:29:in `block in call'",
+              "2.5.0/gems/actionpack-4.2.11/lib/action_dispatch/middleware/callbacks.rb:27:in `call'",
+            ]
+            expected = exception_data.merge('stack' => no_newrelic_backtrace)
+
+            expect(io.received_message).to eq(expected)
+          end
         end
 
         context 'Logging an exception with custom level' do


### PR DESCRIPTION
This is the issue.
A random stacktrace I found had 14K characters in it. 
Some transporters of logs will not be happy over the limit of 16K so some messages with stacktrace can and do sometimes go over the limit due such ginormous stacktraces.

With this patch, we delete around 4K characters of newrelic, leaving us with 10K which should be room enough.

Newrelic is very low value here and even from the readability point of view .a good move to take it out.

Thoughts? @jfeltesse-mdsol  @ssteeg-mdsol @piao-mdsol