### PR TITLE
Use ActiveSupport::BacktraceCleaner to reduce noise in stacktrace output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.3.8
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
 
 before_install:
   - gem install rubygems-update -v 2.7.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,4 @@ rvm:
   - 2.5.7
   - 2.6.5
 
-before_install:
-  - gem install rubygems-update -v 2.7.8
-  - gem install bundler -v 1.17.3
-  - bundle --version
-
 script: bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.10.0
+* Use ActiveSupport::BacktraceCleaner to reduce noise in stacktrace output
+
 # 1.9.0
 * Remove Newrelic instrumentation information from stacktrace output
 

--- a/lib/lorekeeper/json_logger.rb
+++ b/lib/lorekeeper/json_logger.rb
@@ -98,10 +98,10 @@ module Lorekeeper
 
     # Some instrumentation libraries pollute the stacktrace and create a large output which may
     # cause problems with certain logging backends.
-    # Hardcoring newrelic and active_support/callbacks now here.
+    # Hardcording newrelic and active_support/callbacks now here.
     # In the future if this list grows, we may make it configurable.
     def clean_backtrace(backtrace)
-      @backtrace_cleaner ? @backtrace_cleaner.clean(backtrace) : backtrace
+      @backtrace_cleaner&.clean(backtrace) || backtrace
     end
 
     def set_backtrace_cleaner
@@ -109,7 +109,7 @@ module Lorekeeper
 
       cleaner = ActiveSupport::BacktraceCleaner.new
       cleaner.remove_silencers!
-      cleaner.add_silencer { |line| line =~ BLACKLISTED_FINGERPRINT }
+      cleaner.add_silencer { |line| line.match?(BLACKLISTED_FINGERPRINT) }
       cleaner
     end
 

--- a/lib/lorekeeper/version.rb
+++ b/lib/lorekeeper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lorekeeper
-  VERSION = '1.9.0'
+  VERSION = '1.10.0'
 end

--- a/lorekeeper.gemspec
+++ b/lorekeeper.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'oj', '>= 3.4', '< 4.0'
 
+  spec.add_development_dependency 'activesupport', '>= 4.0'
   spec.add_development_dependency 'bundler', '>= 1.16', '< 3.0'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.8'

--- a/lorekeeper.gemspec
+++ b/lorekeeper.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_ruby_version = '>= 2.4.0'
 
   spec.add_dependency 'oj', '>= 3.4', '< 4.0'
 


### PR DESCRIPTION
Use `ActiveSupport::BacktraceCleaner` and add cleaning `active_support/callbacks.rb` calls

From Rails 6, [gem_filter](https://github.com/rails/rails/blob/v6.0.0/activesupport/lib/active_support/backtrace_cleaner.rb#L34) is added

@jcarres-mdsol @jfeltesse-mdsol @ssteeg-mdsol 