### PR TITLE
Oj optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,6 @@ gemfile:
   - gemfiles/without_oj.Gemfile
   - gemfiles/with_oj.Gemfile
 
-script: bundle exec rspec
+script:
+  bundle exec rspec
+  rake benchmark

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ cache: bundler
 rvm:
   - 2.4.9
   - 2.5.7
-  - 2.6.5
+  - 2.6.6
+  - 2.7.2
+  - 3.0.0
+
+gemfile:
+  - gemfiles/without_oj.Gemfile
+  - gemfiles/with_oj.Gemfile
 
 script: bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.11.0
+* Make oj optional, app owner can add it if they want
+
 # 1.10.0
 * Use ActiveSupport::BacktraceCleaner to reduce noise in stacktrace output
 

--- a/gemfiles/with_oj.Gemfile
+++ b/gemfiles/with_oj.Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in lorekeeper.gemspec
+gemspec path: '..'
+
+gem 'oj'

--- a/gemfiles/without_oj.Gemfile
+++ b/gemfiles/without_oj.Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in lorekeeper.gemspec
+gemspec path: '..'

--- a/lib/lorekeeper/json_logger.rb
+++ b/lib/lorekeeper/json_logger.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'json'
 require 'lorekeeper/fast_logger'
 
 module Lorekeeper

--- a/lib/lorekeeper/json_logger.rb
+++ b/lib/lorekeeper/json_logger.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'oj'
 require 'lorekeeper/fast_logger'
 
 module Lorekeeper
@@ -148,7 +147,11 @@ module Lorekeeper
       fields_to_log[TIMESTAMP] = Time.now.utc.strftime(DATE_FORMAT)
       fields_to_log[LEVEL] = SEVERITY_NAMES_MAP[severity]
 
-      @iodevice.write(Oj.dump(fields_to_log) << "\n")
+      if defined?(Oj)
+        @iodevice.write(Oj.dump(fields_to_log) << "\n")
+      else
+        @iodevice.write(fields_to_log.to_json << "\n")
+      end
     end
   end
 end

--- a/lib/lorekeeper/version.rb
+++ b/lib/lorekeeper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lorekeeper
-  VERSION = '1.10.0'
+  VERSION = '1.11.0'
 end

--- a/lorekeeper.gemspec
+++ b/lorekeeper.gemspec
@@ -22,8 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4.0'
 
-  spec.add_dependency 'oj', '>= 3.4', '< 4.0'
-
   spec.add_development_dependency 'activesupport', '>= 4.0'
   spec.add_development_dependency 'bundler', '>= 1.16', '< 3.0'
   spec.add_development_dependency 'rake', '~> 12.0'

--- a/spec/support/fake_io.rb
+++ b/spec/support/fake_io.rb
@@ -22,10 +22,20 @@ end
 
 class FakeJSONIO < FakeIO
   def received_message
-    @msg && Oj.load(@msg)
+    @msg && load_json(@msg)
   end
 
   def received_messages
-    @received_messages.map { |m| Oj.load(m) }
+    @received_messages.map { |m| load_json(m) }
+  end
+
+  private
+
+  def load_json(message)
+    if defined?(Oj)
+      Oj.load(message)
+    else
+      JSON.parse(message)
+    end
   end
 end


### PR DESCRIPTION
As suggested in #17 

`Oj` can be made optional. This will only use it if its already required.

For those applications using `Oj` behavior is expected to be 1:1.
For others who choose not to include `Oj`, it will fall back to the default `JSON` from ruby

I also added ruby 2.7 and 3.0 to the build matrix
