### PR TITLE
Modify FastLogger#add to log progname as a message if no message and block are given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.11.1
+* Modify FastLogger#add to log progname as a message if no message and block are given
+
 # 1.11.0
 * Support for activerecord-session_store v2 which calls only silence and not silence_logger
 

--- a/lib/lorekeeper/fast_logger.rb
+++ b/lib/lorekeeper/fast_logger.rb
@@ -54,9 +54,9 @@ module Lorekeeper
     end
 
     # This is part of the standard Logger API, we need this to be compatible
-    def add(severity, message_param = nil, _ = nil, &block)
+    def add(severity, message_param = nil, progname = nil, &block)
       return true if severity < @level
-      message = message_param || (block && block.call)
+      message = message_param || (block && block.call) || progname
       log_data(severity, message.freeze)
     end
 

--- a/lib/lorekeeper/version.rb
+++ b/lib/lorekeeper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lorekeeper
-  VERSION = '1.11.0'
+  VERSION = '1.11.1'
 end

--- a/spec/lib/lorekeeper/fast_logger_spec.rb
+++ b/spec/lib/lorekeeper/fast_logger_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Lorekeeper::FastLogger do
   let(:io) { FakeIO.new }
   let(:logger) { described_class.new(io) }
   let(:message) { 'And think that I may never live to trace their shadows' }
+  let(:progname) { 'my_progname' }
 
   describe 'log levels' do
     LEVEL_CHECKERS =
@@ -52,6 +53,23 @@ RSpec.describe Lorekeeper::FastLogger do
       logger = described_class.new(filename)
       logger.error(message)
       expect(File.read(filename)).to eq(message)
+    end
+  end
+
+  describe '#add' do
+    it 'logs the message_param' do
+      expect(logger).to receive(:log_data).with(described_class::DEBUG, message)
+      logger.add(described_class::DEBUG, message, progname)
+    end
+
+    it 'logs the block if no message_param is given' do
+      expect(logger).to receive(:log_data).with(described_class::DEBUG, message)
+      logger.add(described_class::DEBUG, nil, progname) { message }
+    end
+
+    it 'logs the progname if no message and block are given' do
+      expect(logger).to receive(:log_data).with(described_class::DEBUG, progname)
+      logger.add(described_class::DEBUG, nil, progname)
     end
   end
 


### PR DESCRIPTION
opentelemetry-ruby is wrapping a logger with `ForwardingLogger` and passing `progname` to the logger, not `message`:

https://github.com/open-telemetry/opentelemetry-ruby/blob/opentelemetry-sdk/v1.0.0.rc2/sdk/lib/opentelemetry/sdk/forwarding_logger.rb#L38-L46

```ruby
      def add(severity, message = nil, progname = nil)
        return true if severity < @level

        @logger.add(severity, message, progname)
      end

      def debug(progname = nil, &block)
        add(Logger::DEBUG, nil, progname, &block)
      end
```

Ruby logger is [treating `progname` as a message if no message and block are given](https://docs.ruby-lang.org/en/3.0.0/Logger.html#method-i-add-label-Args):

https://github.com/ruby/logger/blob/v1.4.3/lib/logger.rb#L467-L474

```ruby
    if message.nil?
      if block_given?
        message = yield
      else
        message = progname
        progname = @progname
      end
    end
```

Modified `FastLogger#add` to follow this pattern.

@jcarres-mdsol @jfeltesse-mdsol 