### PR TITLE
Set 'mode: :compat' in Oj.dump to stringify keys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0']
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1']
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.0
+* Set `mode: :compat` in Oj.dump to stringify keys
+* Support Ruby 3.1
+* Drop support for Ruby < 2.5.0
+
 # 1.12.0
 * Remove ZipkinTracer information from stacktrace output
 * Move CI to GitHub Actions

--- a/lib/lorekeeper/json_logger.rb
+++ b/lib/lorekeeper/json_logger.rb
@@ -148,7 +148,7 @@ module Lorekeeper
       fields_to_log[TIMESTAMP] = Time.now.utc.strftime(DATE_FORMAT)
       fields_to_log[LEVEL] = SEVERITY_NAMES_MAP[severity]
 
-      @iodevice.write(Oj.dump(fields_to_log, mode: :compat) << "\n")
+      @iodevice.write(Oj.dump(fields_to_log, mode: :compat, cache_keys: true, cache_str: 5) << "\n")
     end
   end
 end

--- a/lib/lorekeeper/json_logger.rb
+++ b/lib/lorekeeper/json_logger.rb
@@ -148,7 +148,7 @@ module Lorekeeper
       fields_to_log[TIMESTAMP] = Time.now.utc.strftime(DATE_FORMAT)
       fields_to_log[LEVEL] = SEVERITY_NAMES_MAP[severity]
 
-      @iodevice.write(Oj.dump(fields_to_log) << "\n")
+      @iodevice.write(Oj.dump(fields_to_log, mode: :compat) << "\n")
     end
   end
 end

--- a/lib/lorekeeper/version.rb
+++ b/lib/lorekeeper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lorekeeper
-  VERSION = '1.12.0'
+  VERSION = '2.0.0'
 end

--- a/lorekeeper.gemspec
+++ b/lorekeeper.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.5.0'
 
-  spec.add_dependency 'oj', '>= 3.4', '< 4.0'
+  spec.add_dependency 'oj', '>= 3.12', '< 4.0'
 
   spec.add_development_dependency 'activesupport', '>= 4.0'
   spec.add_development_dependency 'bundler', '>= 1.16', '< 3.0'

--- a/lorekeeper.gemspec
+++ b/lorekeeper.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'oj', '>= 3.4', '< 4.0'
 

--- a/spec/lib/lorekeeper/json_logger_spec.rb
+++ b/spec/lib/lorekeeper/json_logger_spec.rb
@@ -223,6 +223,24 @@ RSpec.describe Lorekeeper do
           end
         end
 
+        context 'Logging an exception with custom message and data in symbol key' do
+          let(:data_with_symbol_key) { { some: 'data' } }
+          let(:exception_data) do
+            base_message
+              .merge(
+                'exception' => "StandardError: #{exception_msg}",
+                'message' => message,
+                'stack' => stack
+              )
+              .merge(data_field)
+              .merge(error_level)
+          end
+          it 'Logs the exception with data in string key' do
+            logger.exception(exception, message: message, data: data_with_symbol_key)
+            expect(io.received_message).to eq(exception_data)
+          end
+        end
+
         context 'logging an exception without backtrace' do
           let(:stack) { [] }
           before do


### PR DESCRIPTION
All in the title

### Performance
this change slows down the performance a little


#### Ruby 2.7
with `mode: :compat`
```
  JSON short content     93.920k (± 0.7%) i/s -    478.533k in   5.095383s
Logger short content    106.209k (± 0.8%) i/s -    536.100k in   5.047894s
   JSON long content     45.085k (±11.5%) i/s -    227.424k in   5.142470s
 Logger long content     35.762k (±34.6%) i/s -    156.832k in   5.043390s
```

without `mode: :compat`
```
  JSON short content    107.124k (± 6.2%) i/s -    545.670k in   5.112505s
Logger short content    109.938k (± 1.1%) i/s -    555.500k in   5.053470s
   JSON long content     45.739k (±13.6%) i/s -    223.605k in   5.019013s
 Logger long content     34.799k (±30.5%) i/s -    158.652k in   5.006122s
```
#### Ruby 3.0
with `mode: :compat`
```
  JSON short content     88.108k (± 3.4%) i/s -    441.490k in   5.016234s
Logger short content     97.983k (± 3.7%) i/s -    493.773k in   5.046516s
   JSON long content     42.026k (± 3.8%) i/s -    212.670k in   5.068215s
 Logger long content     31.937k (±14.6%) i/s -    161.107k in   5.135188s
```

without `mode: :compat`
```
  JSON short content     98.295k (± 1.5%) i/s -    499.647k in   5.084235s
Logger short content     97.783k (± 2.5%) i/s -    491.088k in   5.025475s
   JSON long content     44.083k (± 6.8%) i/s -    224.077k in   5.116877s
 Logger long content     30.401k (± 8.0%) i/s -    155.190k in   5.138547s
```
#### Ruby 3.1
with `mode: :compat`
```
  JSON short content     89.399k (± 0.6%) i/s -    449.150k in   5.024249s
Logger short content     98.255k (± 1.8%) i/s -    494.450k in   5.034118s
   JSON long content     43.882k (± 6.2%) i/s -    223.150k in   5.109795s
 Logger long content     30.615k (± 7.8%) i/s -    152.199k in   5.001883s
```

without `mode: :compat`
```
  JSON short content     96.925k (± 0.7%) i/s -    488.400k in   5.039164s
Logger short content     98.041k (± 7.3%) i/s -    492.650k in   5.075970s
   JSON long content     44.712k (±11.3%) i/s -    226.368k in   5.153677s
 Logger long content     31.410k (± 9.0%) i/s -    156.828k in   5.033354s
```

@jcarres-mdsol @jfeltesse-mdsol