### PR TITLE
Modify SimpleLogger to properly log exceptions with named parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.1.0
+* Modify SimpleLogger to properly log exceptions with named parameters
+
 # 2.0.0
 * Set `mode: :compat` in Oj.dump to stringify keys
 * Support Ruby 3.1

--- a/lib/lorekeeper/simple_logger.rb
+++ b/lib/lorekeeper/simple_logger.rb
@@ -25,15 +25,6 @@ module Lorekeeper
       UNKNOWN => COLOR_LIGHT_GRAY
     }.freeze
 
-    JSON_LOGGER_METHODS = [
-      :current_fields,
-      :state,
-      :add_thread_unsafe_fields,
-      :remove_thread_unsafe_fields,
-      :add_fields,
-      :remove_fields
-    ].freeze
-
     # \e[colorm sets a color \e[0m resets all properties
     def log_data(severity, message)
       color = SEVERITY_TO_COLOR_MAP[severity]
@@ -53,9 +44,12 @@ module Lorekeeper
     end
 
     # To not raise NoMethodError for the methods defined in JSONLogger
-    JSON_LOGGER_METHODS.each do |method_name|
-      define_method method_name, ->(*, &block) {}
-    end
+    def current_fields(*); end
+    def state(*); end
+    def add_thread_unsafe_fields(*); end
+    def remove_thread_unsafe_fields(*); end
+    def add_fields(*); end
+    def remove_fields(*); end
 
     def exception(exception, custom_message = nil, custom_data = nil, custom_level = :error,
                              message: nil, data: nil, level: nil)

--- a/lib/lorekeeper/version.rb
+++ b/lib/lorekeeper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lorekeeper
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end

--- a/spec/lib/lorekeeper/simple_logger_spec.rb
+++ b/spec/lib/lorekeeper/simple_logger_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Lorekeeper::SimpleLogger do
     end
 
     context 'with a custom_data' do
-      let(:custom_data) { { command: "java -jar openapi-generator.jar generate" }  }
+      let(:custom_data) { { command: "java -jar openapi-generator.jar generate" } }
       let(:expected) do
         "\e[31mStandardError: #{exception_msg}; #{exception_msg} \n\nstack:\nFirst line\nSecond line " \
         "\n\ndata:\n{:command=>\"java -jar openapi-generator.jar generate\"}\e[0m\n"
@@ -111,7 +111,9 @@ RSpec.describe Lorekeeper::SimpleLogger do
   end
 
   describe 'JSONLogger methods' do
-    described_class::JSON_LOGGER_METHODS.each do |method|
+    %i[
+      current_fields state add_thread_unsafe_fields remove_thread_unsafe_fields add_fields remove_fields
+    ].each do |method|
       it "does not raise NoMethodError for the #{method} method" do
         expect { logger.send(method) }.to_not raise_error
       end


### PR DESCRIPTION
Modify SimpleLogger to:
- support named parameters which is added to JSONLogger in #14
- log `data`
- not raise `NoMethodError` for the methods defined in JSONLogger
- replace `'\n'` & `'\t'` with `"\n"` & `"\t"`

@jcarres-mdsol @jfeltesse-mdsol 