### PR TITLE
Remove metaprogramming from Multilogger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby-version: ['2.7', '3.0', '3.1']
 
     steps:
     - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,6 @@
 Metrics/LineLength:
   Max: 120
+# https://github.com/rubocop/rubocop/blob/20990ed3831589c0d9f202107b1b580ead8ef2c5/lib/rubocop/cop/style/single_line_methods.rb#L11
+# TODO: add "EnforcedStyle: allow_single_line" once all rubys are > 3.0 to autocorrect all single-line methods to endless
+Style/SingleLineMethods:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.0
+* Remove metaprogramming from MultiLogger
+* Drop support for Ruby < 2.7.0
+
 # 2.1.0
 * Modify SimpleLogger to properly log exceptions with named parameters
 

--- a/lib/lorekeeper/fast_logger.rb
+++ b/lib/lorekeeper/fast_logger.rb
@@ -56,7 +56,7 @@ module Lorekeeper
     # This is part of the standard Logger API, we need this to be compatible
     def add(severity, message_param = nil, progname = nil, &block)
       return true if severity < @level
-      message = message_param || (block && block.call) || progname
+      message = (block && block.call) || message_param || progname
       log_data(severity, message.freeze)
     end
 

--- a/lib/lorekeeper/json_logger.rb
+++ b/lib/lorekeeper/json_logger.rb
@@ -8,7 +8,7 @@ module Lorekeeper
   class JSONLogger < FastLogger
     def initialize(file)
       reset_state
-      @base_fields = { MESSAGE => '', TIMESTAMP => '', LEVEL => '' }
+      @base_fields = { TIMESTAMP => '', MESSAGE => '', LEVEL => '' }
       @backtrace_cleaner = set_backtrace_cleaner
       super(file)
     end

--- a/lib/lorekeeper/multi_logger.rb
+++ b/lib/lorekeeper/multi_logger.rb
@@ -17,15 +17,20 @@ module Lorekeeper
     end
 
     # Define all common logging methods within Multilogger to avoid NoMethodError
-    FastLogger::LOGGING_METHODS.each do |method_name|
-      define_method method_name.to_s, ->(*args, &block) do
-        call_loggers(method_name, *args, &block)
-      end
+    def debug(*args, &block); call_loggers(:debug, *args, &block); end
+    def debug_with_data(*args, &block); call_loggers(:debug, *args, &block); end
 
-      define_method "#{method_name}_with_data", ->(*args, &block) do
-        call_loggers(method_name, *args, &block)
-      end
-    end
+    def info(*args, &block); call_loggers(:info, *args, &block); end
+    def info_with_data(*args, &block); call_loggers(:info, *args, &block); end
+
+    def warn(*args, &block); call_loggers(:warn, *args, &block); end
+    def warn_with_data(*args, &block); call_loggers(:warn, *args, &block); end
+
+    def error(*args, &block); call_loggers(:error, *args, &block); end
+    def error_with_data(*args, &block); call_loggers(:error, *args, &block); end
+
+    def fatal(*args, &block); call_loggers(:fatal, *args, &block); end
+    def fatal_with_data(*args, &block); call_loggers(:fatal, *args, &block); end
 
 if RUBY_VERSION > "2.6"
     def respond_to?(method, all_included = false)

--- a/lib/lorekeeper/multi_logger.rb
+++ b/lib/lorekeeper/multi_logger.rb
@@ -37,7 +37,7 @@ module Lorekeeper
 
     def fatal_with_data(*args, &block); call_loggers(:fatal, *args, &block); end
 
-    def write(*args, &block); call_loggers(:write, *args, &block); end
+    def write(*args); call_loggers(:write, *args); end
 
     def respond_to?(method, all_included: false)
       @loggers.all? { |logger| logger.respond_to?(method, all_included) }

--- a/lib/lorekeeper/multi_logger.rb
+++ b/lib/lorekeeper/multi_logger.rb
@@ -37,14 +37,8 @@ module Lorekeeper
 
     def fatal_with_data(*args, &block); call_loggers(:fatal, *args, &block); end
 
-    if RUBY_VERSION > '2.6'
-      def respond_to?(method, all_included: false)
-        @loggers.all? { |logger| logger.respond_to?(method, all_included) }
-      end
-    else
-      def respond_to?(method)
-        @loggers.all? { |logger| logger.respond_to?(method) }
-      end
+    def respond_to?(method, all_included: false)
+      @loggers.all? { |logger| logger.respond_to?(method, all_included) }
     end
 
     def call_loggers(method, *args, &block)

--- a/lib/lorekeeper/multi_logger.rb
+++ b/lib/lorekeeper/multi_logger.rb
@@ -18,29 +18,34 @@ module Lorekeeper
 
     # Define all common logging methods within Multilogger to avoid NoMethodError
     def debug(*args, &block); call_loggers(:debug, *args, &block); end
+
     def debug_with_data(*args, &block); call_loggers(:debug, *args, &block); end
 
     def info(*args, &block); call_loggers(:info, *args, &block); end
+
     def info_with_data(*args, &block); call_loggers(:info, *args, &block); end
 
     def warn(*args, &block); call_loggers(:warn, *args, &block); end
+
     def warn_with_data(*args, &block); call_loggers(:warn, *args, &block); end
 
     def error(*args, &block); call_loggers(:error, *args, &block); end
+
     def error_with_data(*args, &block); call_loggers(:error, *args, &block); end
 
     def fatal(*args, &block); call_loggers(:fatal, *args, &block); end
+
     def fatal_with_data(*args, &block); call_loggers(:fatal, *args, &block); end
 
-if RUBY_VERSION > "2.6"
-    def respond_to?(method, all_included = false)
-      @loggers.all? { |logger| logger.respond_to?(method, all_included) }
+    if RUBY_VERSION > '2.6'
+      def respond_to?(method, all_included: false)
+        @loggers.all? { |logger| logger.respond_to?(method, all_included) }
+      end
+    else
+      def respond_to?(method)
+        @loggers.all? { |logger| logger.respond_to?(method) }
+      end
     end
-else
-    def respond_to?(method)
-      @loggers.all? { |logger| logger.respond_to?(method) }
-    end
-end
 
     def call_loggers(method, *args, &block)
       result = @loggers.map do |logger|

--- a/lib/lorekeeper/multi_logger.rb
+++ b/lib/lorekeeper/multi_logger.rb
@@ -37,6 +37,8 @@ module Lorekeeper
 
     def fatal_with_data(*args, &block); call_loggers(:fatal, *args, &block); end
 
+    def write(*args, &block); call_loggers(:write, *args, &block); end
+
     def respond_to?(method, all_included: false)
       @loggers.all? { |logger| logger.respond_to?(method, all_included) }
     end

--- a/lib/lorekeeper/version.rb
+++ b/lib/lorekeeper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lorekeeper
-  VERSION = '2.1.0'
+  VERSION = '2.2.0'
 end

--- a/lorekeeper.gemspec
+++ b/lorekeeper.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 2.7.0'
 
   spec.add_dependency 'oj', '>= 3.12', '< 4.0'
 

--- a/spec/lib/lorekeeper/json_logger_spec.rb
+++ b/spec/lib/lorekeeper/json_logger_spec.rb
@@ -33,17 +33,9 @@ RSpec.describe Lorekeeper do
           logger.send(method, message)
           expect(io.received_message).to eq(expected.merge('level' => level_name.(method)))
         end
-        it 'The first key is timestamp' do
+        it 'preserves the order of keys' do
           logger.send(method, message)
-          expect(io.received_message.keys[0]).to eq('timestamp')
-        end
-        it 'The second key is message' do
-          logger.send(method, message)
-          expect(io.received_message.keys[1]).to eq('message')
-        end
-        it 'The third key is the level' do
-          logger.send(method, message)
-          expect(io.received_message.keys[2]).to eq('level')
+          expect(io.received_message.keys[0..2]).to eq(['timestamp', 'message', 'level'])
         end
         it "Outputs the correct format for #{method}_with_data" do
           logger.send("#{method}_with_data", message, data)

--- a/spec/lib/lorekeeper/json_logger_spec.rb
+++ b/spec/lib/lorekeeper/json_logger_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Lorekeeper do
         end
         it 'preserves the order of keys' do
           logger.send(method, message)
-          expect(io.received_message.keys[0..2]).to eq(['timestamp', 'message', 'level'])
+          expect(io.received_message.keys[0..2]).to eq(%w[timestamp message level])
         end
         it "Outputs the correct format for #{method}_with_data" do
           logger.send("#{method}_with_data", message, data)

--- a/spec/lib/lorekeeper/json_logger_spec.rb
+++ b/spec/lib/lorekeeper/json_logger_spec.rb
@@ -33,13 +33,13 @@ RSpec.describe Lorekeeper do
           logger.send(method, message)
           expect(io.received_message).to eq(expected.merge('level' => level_name.(method)))
         end
-        it 'The first key is message' do
+        it 'The first key is timestamp' do
           logger.send(method, message)
-          expect(io.received_message.keys[0]).to eq('message')
+          expect(io.received_message.keys[0]).to eq('timestamp')
         end
-        it 'The second key is the timestamp' do
+        it 'The second key is message' do
           logger.send(method, message)
-          expect(io.received_message.keys[1]).to eq('timestamp')
+          expect(io.received_message.keys[1]).to eq('message')
         end
         it 'The third key is the level' do
           logger.send(method, message)

--- a/spec/lib/lorekeeper/multi_logger_spec.rb
+++ b/spec/lib/lorekeeper/multi_logger_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Lorekeeper::MultiLogger do
     let(:message) { 'My heart aches, and a drowsy numbness pains my sense' }
     let(:console_logger) { Lorekeeper::SimpleLogger.new(io) }
     let(:json_logger) { Lorekeeper::JSONLogger.new(json_io) }
+    let(:fakeio) { FakeIO.new }
 
     it 'calls all log level methods of loggers' do
       logger.add_logger(console_logger)
@@ -34,9 +35,10 @@ RSpec.describe Lorekeeper::MultiLogger do
     end
 
     it 'calls write method of loggers' do
+      logger.add_logger(fakeio)
+
       logger.write(message)
-      expect(io.received_message).to eq(message)
-      expect(io2.received_message).to eq(message)
+      expect(fakeio.received_message).to eq(message)
     end
   end
 end

--- a/spec/lib/lorekeeper/multi_logger_spec.rb
+++ b/spec/lib/lorekeeper/multi_logger_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Lorekeeper::MultiLogger do
   let(:io) { FakeIO.new }
-  let(:io2) { FakeIO.new }
+  let(:json_io) { FakeJSONIO.new }
   let(:logger) { described_class.new }
 
   context 'no loggers added' do
@@ -15,22 +15,22 @@ RSpec.describe Lorekeeper::MultiLogger do
 
   context 'loggers added' do
     let(:message) { 'My heart aches, and a drowsy numbness pains my sense' }
+    let(:console_logger) { Lorekeeper::SimpleLogger.new(io) }
+    let(:json_logger) { Lorekeeper::JSONLogger.new(json_io) }
 
-    before do
-      logger.add_logger(io)
-      logger.add_logger(io2)
-    end
+    it 'calls all the methods of the loggers' do
+      logger.add_logger(console_logger)
+      logger.add_logger(json_logger)
 
-    it 'calls the methods of the loggers' do
-      logger.write(message)
-      expect(io.received_message).to eq(message)
-      expect(io2.received_message).to eq(message)
-    end
+      Lorekeeper::FastLogger::LOGGING_METHODS.each do |log_level|
+        logger.send(log_level, message) if logger.respond_to? (log_level)
 
-    it 'does not call the methods if they do not exist' do
-      logger.idonotexist(message)
-      expect(io.received_message).to eq(nil)
-      expect(io2.received_message).to eq(nil)
+        expect(io.received_message).to include(message)
+        expect(json_io.received_message).to include(
+          'message' => message,
+          'level' => log_level == :warn ? 'warning' : log_level.to_s
+        )
+      end
     end
   end
 end

--- a/spec/lib/lorekeeper/multi_logger_spec.rb
+++ b/spec/lib/lorekeeper/multi_logger_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Lorekeeper::MultiLogger do
     let(:console_logger) { Lorekeeper::SimpleLogger.new(io) }
     let(:json_logger) { Lorekeeper::JSONLogger.new(json_io) }
 
-    it 'calls all the methods of the loggers' do
+    it 'calls all log level methods of loggers' do
       logger.add_logger(console_logger)
       logger.add_logger(json_logger)
 
@@ -31,6 +31,12 @@ RSpec.describe Lorekeeper::MultiLogger do
           'level' => log_level == :warn ? 'warning' : log_level.to_s
         )
       end
+    end
+
+    it 'calls write method of loggers' do
+      logger.write(message)
+      expect(io.received_message).to eq(message)
+      expect(io2.received_message).to eq(message)
     end
   end
 end


### PR DESCRIPTION
### Changes in this PR

1. replace `method_missing` metaprogramming with logging method definitions in `MultiLogger`
2. change order of expressions of message assignments in `FastLogger`
3. make `timestamp` the first key in `JSONLogger` message

### Background

#### 1
There are some cases when services check for logging method definitions before invoking them, e.g.

```
if logger.respond_to?(:info)
	# do some cool stuff
else
	# ooops
end
```

It breaks in case of `MultiLogger` since it doesn't implement logging methods, it uses metaprogramming to delegate them to logger instances.


#### 2

Some services use `progname` whereas Lorekeeper drops it, so the output response it not logged properly.
Instead we see

```
request
request
response
response
response
```


#### 3

Some messages may include time related keys, e.g. `last_updated_at`, which tracing services would use as a timestamp, instead of `timestamp` key that is present on the message object which leads to a discrepancy.
Changing the order seems to solve this.

### How to test

I have added specs that should be enough to test the changed behavior.
There is also a way to test all the changes by passing Lorekeeper as Faraday logger and making HTTP request.

You will need to ⬇️ 

1. `mkdir lorekeeper_playground`
2. `touch Gemfile` and add the following

```
/lorekeeper_playground/Gemfile

# frozen_string_literal: true

source "https://rubygems.org"

gem 'lorekeeper'
gem 'faraday'
```

3. `bundle`
4.  `touch logs.txt` (for writing JSON logs)
5.  `touch lorekeeper_playground.rb` and add the following

```
/lorekeeper_playground/lorekeeper_playground.rb

require 'bundler/setup'
require 'lorekeeper'
require 'faraday'

console_logger = Lorekeeper::SimpleLogger.new($stdout)
json_logger = Lorekeeper::JSONLogger.new('./logs.txt')

multi_logger = Lorekeeper::MultiLogger.new
multi_logger.add_logger(console_logger)
multi_logger.add_logger(json_logger)

conn = Faraday.new("http://httpbingo.org/") do |builder|
    builder.request :url_encoded
    builder.response :logger, multi_logger, { bodies: true, log_level: :debug }
    builder.adapter  :net_http
end

conn.get("/html")
```

6. `ruby lorekeeper_playground.rb`

You must see an error and no output, like so

```
/Users/yourusername/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/faraday-2.3.0/lib/faraday/logging/formatter.rb:102: warning:
Faraday::Logging::Formatter#debug at /Users/yourusername/.rbenv/versions/2.7.4/lib/ruby/2.7.0/forwardable.rb:154 forwarding to private method Lorekeeper::MultiLogger#debug
response
```

8. now edit the `Gemfile` so that `lorekepeer` source points to this branch

```
gem 'lorekeeper', git: "https://github.com/JordiPolo/lorekeeper", branch: "feature/remove-metaprogramming"
```

9. don't forget to `bundle` again 😉 
10. `ruby lorekeeper_playground.rb`

You must see logs output in the console + in the `logs.txt` file.
Make sure `timestamp` key comes first in `logs.txt` logs.