### PR TITLE
Ensure extra fields are reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.2.1
+* Ensure additional fields are reset after logging
+
 # 2.2.0
 * Remove metaprogramming from MultiLogger
 * Drop support for Ruby < 2.7.0

--- a/lib/lorekeeper/json_logger.rb
+++ b/lib/lorekeeper/json_logger.rb
@@ -126,6 +126,7 @@ module Lorekeeper
     def with_extra_fields(fields)
       state[:extra_fields] = fields
       yield
+    ensure
       state[:extra_fields] = {}
     end
 


### PR DESCRIPTION
Right now, if an exception is thrown while writing a structured (`_with_data`) log entry the fields stored in `:extra_fields` will persist and be re-used repeatedly by non-structured log writes. This creates fun issues when the data attempting to be serialized is the source of the exception.