### PR TITLE
Fix MultiLogger to not raise ArgumentError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.3.1
+* Fix MultiLogger to not raise ArgumentError
+
 # 2.3.0
 * Add `#write` method support to all loggers
 

--- a/lib/lorekeeper/multi_logger.rb
+++ b/lib/lorekeeper/multi_logger.rb
@@ -19,23 +19,13 @@ module Lorekeeper
     # Define all common logging methods within Multilogger to avoid NoMethodError
     def debug(*args, &block); call_loggers(:debug, *args, &block); end
 
-    def debug_with_data(*args, &block); call_loggers(:debug, *args, &block); end
-
     def info(*args, &block); call_loggers(:info, *args, &block); end
-
-    def info_with_data(*args, &block); call_loggers(:info, *args, &block); end
 
     def warn(*args, &block); call_loggers(:warn, *args, &block); end
 
-    def warn_with_data(*args, &block); call_loggers(:warn, *args, &block); end
-
     def error(*args, &block); call_loggers(:error, *args, &block); end
 
-    def error_with_data(*args, &block); call_loggers(:error, *args, &block); end
-
     def fatal(*args, &block); call_loggers(:fatal, *args, &block); end
-
-    def fatal_with_data(*args, &block); call_loggers(:fatal, *args, &block); end
 
     def write(*args); call_loggers(:write, *args); end
 

--- a/lib/lorekeeper/version.rb
+++ b/lib/lorekeeper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lorekeeper
-  VERSION = '2.3.0'
+  VERSION = '2.3.1'
 end

--- a/spec/lib/lorekeeper/multi_logger_spec.rb
+++ b/spec/lib/lorekeeper/multi_logger_spec.rb
@@ -34,6 +34,24 @@ RSpec.describe Lorekeeper::MultiLogger do
       end
     end
 
+    context 'with data' do
+      it 'calls all log level methods of loggers' do
+        logger.add_logger(console_logger)
+        logger.add_logger(json_logger)
+
+        Lorekeeper::FastLogger::LOGGING_METHODS.each do |log_level|
+          logger.send("#{log_level}_with_data", message, { sum: 123 })
+
+          expect(io.received_message).to include("#{message}, data: {:sum=>123}")
+          expect(json_io.received_message).to include(
+            'message' => message,
+            'level' => log_level == :warn ? 'warning' : log_level.to_s,
+            'data' => { 'sum' => 123 }
+          )
+        end
+      end
+    end
+
     %i[
       current_fields state add_thread_unsafe_fields remove_thread_unsafe_fields add_fields remove_fields
     ].each do |method|


### PR DESCRIPTION
My bad, why did I overlook this in the first place 😓, sorry...

We need to add `~_with_data` when calling the `call_loggers`:
```diff
- def info_with_data(*args, &block); call_loggers(:info, *args, &block); end
+ def info_with_data(*args, &block); call_loggers(:info_with_data, *args, &block); end
```

However, the original purpose of removing metaprogramming is to use lorekeeper with Faraday logger middleware which is  using `public_send`: https://github.com/lostisland/faraday/blob/v2.5.2/lib/faraday/logging/formatter.rb#L26

The methods we need to remove metaprogramming for the middleware are common ones (`%i[debug info warn error fatal]`):
https://github.com/lostisland/faraday/blob/v2.5.2/lib/faraday/logging/formatter.rb#L88

The `~_with_data` methods are original methods in lorekeeper and we added back `method_missing` in #30 so we can undo removing metaprogramming.

Preserved the `write` method, just in case.

Added a spec to test the `~_with_data` methods in MultiLogger

@jcarres-mdsol @jfeltesse-mdsol @miniengineer 