### PR TITLE
Fix Lorekeeper::BacktraceCleaner#clean to not raise when a non-array value is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.6.1
+* Fix Lorekeeper::BacktraceCleaner#clean to not raise when a non-array value is passed
+
 # 2.6.0
 * Expose Lorekeeper::BacktraceCleaner
 

--- a/lib/lorekeeper/backtrace_cleaner.rb
+++ b/lib/lorekeeper/backtrace_cleaner.rb
@@ -15,6 +15,8 @@ module Lorekeeper
     end
 
     def clean(backtrace)
+      return [] unless backtrace.is_a?(Array)
+
       backtrace = filter_rails_root_backtrace(backtrace)
       @backtrace_cleaner&.clean(backtrace) || backtrace
     end

--- a/lib/lorekeeper/version.rb
+++ b/lib/lorekeeper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lorekeeper
-  VERSION = '2.6.0'
+  VERSION = '2.6.1'
 end

--- a/spec/lib/lorekeeper/backtrace_cleaner_spec.rb
+++ b/spec/lib/lorekeeper/backtrace_cleaner_spec.rb
@@ -100,6 +100,10 @@ RSpec.describe Lorekeeper do
           ])
         end
 
+        it 'returns an empty array when nil is passed' do
+          expect(instance.clean(nil)).to eq([])
+        end
+
         context 'with LOREKEEPER_DENYLIST env var' do
           before do
             allow(ENV).to receive(:key?).with('LOREKEEPER_DENYLIST').and_return(true)


### PR DESCRIPTION
Title says all

@jcarres-mdsol 