### PR TITLE
Fix respond_to? method signature for optional second positional arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.6.2
+* Fix respond_to? method signature
+
 # 2.6.1
 * Fix Lorekeeper::BacktraceCleaner#clean to not raise when a non-array value is passed
 

--- a/lib/lorekeeper/multi_logger.rb
+++ b/lib/lorekeeper/multi_logger.rb
@@ -29,8 +29,8 @@ module Lorekeeper
 
     def write(*args); call_loggers(:write, *args); end
 
-    def respond_to?(method, all_included: false)
-      @loggers.all? { |logger| logger.respond_to?(method, all_included) }
+    def respond_to?(method, include_all=false)
+      @loggers.all? { |logger| logger.respond_to?(method, include_all) }
     end
 
     def call_loggers(method, *args, &block)

--- a/lib/lorekeeper/version.rb
+++ b/lib/lorekeeper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lorekeeper
-  VERSION = '2.6.1'
+  VERSION = '2.6.2'
 end


### PR DESCRIPTION
dalton's rails 7.1 upgrade uncovered this. rails 7.1 makes the broadcast logger api public https://github.com/rails/rails/blob/7-1-stable/activesupport/CHANGELOG.md#rails-710rc1-september-27-2023. during our db seed process the broadcast logger calls `respond_to?` with the optional second positional arg: https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/broadcast_logger.rb#L239 this was causing an `ArgumentError: wrong number of arguments (given 2, expected 1)` in lorekeeper because lorekeeper has the second arg declared as a kwarg. as far as i can tell it's never been a kwarg but probably nothing has attempted to call it with a second positional arg 