### PR TITLE
Fix Lorekeeper::BacktraceCleaner to support BacktraceLocation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
             ruby: '2.7'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,15 +14,19 @@ AllCops:
   #
     - 'vendor/bundle/**/*'
 
-Lint/ConstantDefinitionInBlock:
-  Exclude:
-    - 'spec/**/*'
-
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
 
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
+
+Lint/ConstantDefinitionInBlock:
+  Exclude:
+    - 'spec/**/*'
+
+Lint/StructNewOverride:
+  Exclude:
+    - spec/lib/lorekeeper/backtrace_cleaner_spec.rb
 
 Metrics/ParameterLists:
   CountKeywordArgs: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.6.3
+* Fix Lorekeeper::BacktraceCleaner to support BacktraceLocation
+
 # 2.6.2
 * Fix respond_to? method signature
 

--- a/lib/lorekeeper/backtrace_cleaner.rb
+++ b/lib/lorekeeper/backtrace_cleaner.rb
@@ -38,6 +38,7 @@ module Lorekeeper
       last_index = nil
       result = []
       backtrace.each_with_index do |line, idx|
+        line = line.to_s
         if line.start_with?(@rails_root) && @gem_path.none? { |path| line.start_with?(path) }
           result << line[@rails_root_size..]
           last_index = idx

--- a/lib/lorekeeper/json_logger.rb
+++ b/lib/lorekeeper/json_logger.rb
@@ -28,10 +28,10 @@ module Lorekeeper
     # Delegates methods to the existing Logger instance
     # We are extending the logger API with methods error_with_data, etc
     LOGGING_METHODS.each do |method_name|
-      define_method "#{method_name}_with_data", ->(message_param = nil, data = {}, &block) {
+      define_method :"#{method_name}_with_data", ->(message_param = nil, data = {}, &block) {
         return true if METHOD_SEVERITY_MAP[method_name] < @level
 
-        extra_fields = { DATA => (data || {}) }
+        extra_fields = { DATA => data || {} }
         with_extra_fields(extra_fields) do
           add(METHOD_SEVERITY_MAP[method_name], message_param, nil, &block)
         end
@@ -87,7 +87,7 @@ module Lorekeeper
       else
         log_data(METHOD_SEVERITY_MAP[:warn], 'Logger exception called without exception class.')
         message = "#{exception.class}: #{exception.inspect} #{param_message}"
-        with_extra_fields(DATA => (param_data || {})) { log_data(log_level, message) }
+        with_extra_fields(DATA => param_data || {}) { log_data(log_level, message) }
       end
     end
 

--- a/lib/lorekeeper/simple_logger.rb
+++ b/lib/lorekeeper/simple_logger.rb
@@ -38,7 +38,7 @@ module Lorekeeper
 
     # Extending the logger API with methods error_with_data, etc
     LOGGING_METHODS.each do |method_name|
-      define_method "#{method_name}_with_data", ->(message_param = nil, data = {}) {
+      define_method :"#{method_name}_with_data", ->(message_param = nil, data = {}) {
         return true if METHOD_SEVERITY_MAP[method_name] < @level
 
         log_data(METHOD_SEVERITY_MAP[method_name], "#{message_param}, data: #{data}")

--- a/lib/lorekeeper/version.rb
+++ b/lib/lorekeeper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lorekeeper
-  VERSION = '2.6.2'
+  VERSION = '2.6.3'
 end

--- a/spec/lib/lorekeeper/json_logger_spec.rb
+++ b/spec/lib/lorekeeper/json_logger_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Lorekeeper do
           expect(io.received_message.keys[0..2]).to eq(%w[timestamp message level])
         end
         it "Outputs the correct format for #{method}_with_data" do
-          logger.send("#{method}_with_data", message, data)
+          logger.send(:"#{method}_with_data", message, data)
           expect(io.received_message).to eq(expected_data.merge('level' => level_name.call(method)))
         end
       end
@@ -396,7 +396,7 @@ RSpec.describe Lorekeeper do
         end
         it "No data is written to the device for #{method}_with_data" do
           expect(io).not_to receive(:write)
-          logger.send("#{method}_with_data", message, data)
+          logger.send(:"#{method}_with_data", message, data)
         end
       end
     end

--- a/spec/lib/lorekeeper/multi_logger_spec.rb
+++ b/spec/lib/lorekeeper/multi_logger_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Lorekeeper::MultiLogger do
         logger.add_logger(json_logger)
 
         Lorekeeper::FastLogger::LOGGING_METHODS.each do |log_level|
-          logger.send("#{log_level}_with_data", message, { sum: 123 })
+          logger.send(:"#{log_level}_with_data", message, { sum: 123 })
 
           expect(io.received_message).to include("#{message}, data: {:sum=>123}")
           expect(json_io.received_message).to include(


### PR DESCRIPTION
observing the following error with Ruby3.2 + Rails7.1.2:

> undefined method `start_with?' for "../ruby/3.2.2/lib/ruby/gems/3.2.0/gems/actionpack-7.1.2/lib/action_dispatch/middleware/debug_exceptions.rb:34:in `call'":Thread::Backtrace::Location`

This change was made in Rails (I guess from `7.1.0`?):
- https://github.com/rails/rails/pull/45818

The result of the [`backtrace` method](https://github.com/rails/rails/pull/45818/files#diff-2403d29eb778f71272202e446d3fd53332ad6198260615f6f28172474e8527b5R152) can be an array of strings or an array of [backtrace locations](https://github.com/rails/rails/blob/v7.1.2/activesupport/lib/active_support/syntax_error_proxy.rb#L15-L21)

Adding `.to_s` [like in the PR](https://github.com/rails/rails/pull/45818/files#diff-895b194d1cd076295b52cf047d3452420d42f082f4208f4e97e1a9eb87caf0ee)