### PR TITLE
Reorder the exception fields to have the `data` field before the `exception` field

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,18 +15,23 @@ jobs:
     strategy:
       matrix:
         ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
-        rails: ['5.2.7', '6.0.4', '6.1.7', '7.0.8', '7.1.1']
+        rails: ['5.2.8', '6.0.6', '6.1.7', '7.0.8', '7.1.4', '7.2.1']
         include:
-          - rails: '4.0.1'
+          - rails: '4.0.13'
             ruby: '2.7'
-          - rails: '4.1.1'
+          - rails: '4.1.16'
             ruby: '2.7'
-          - rails: '4.2.1'
+          - rails: '4.2.11'
             ruby: '2.7'
-          - rails: '5.0.1'
+          - rails: '5.0.7'
             ruby: '2.7'
-          - rails: '5.1.1'
+          - rails: '5.1.7'
             ruby: '2.7'
+        exclude:
+          - rails: '7.2.1'
+            ruby: '2.7'
+          - rails: '7.2.1'
+            ruby: '3.0'
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.6.4
+* Reorder the exception fields to have the `data` field before the `exception` field
+
 # 2.6.3
 * Fix Lorekeeper::BacktraceCleaner to support BacktraceLocation
 

--- a/lib/lorekeeper/json_logger.rb
+++ b/lib/lorekeeper/json_logger.rb
@@ -10,7 +10,7 @@ module Lorekeeper
       reset_state
       @base_fields = { TIMESTAMP => '', MESSAGE => '', LEVEL => '' }
 
-      super(file)
+      super
     end
 
     def current_fields
@@ -77,10 +77,11 @@ module Lorekeeper
       if exception.is_a?(Exception)
         backtrace = clean_backtrace(exception.backtrace || [])
         exception_fields = {
+          DATA => param_data,
           EXCEPTION => "#{exception.class}: #{exception.message}",
           STACK => backtrace
         }
-        exception_fields[DATA] = param_data if param_data
+        exception_fields.compact!
 
         message = param_message || exception.message
         with_extra_fields(exception_fields) { log_data(log_level, message) }

--- a/lib/lorekeeper/version.rb
+++ b/lib/lorekeeper/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lorekeeper
-  VERSION = '2.6.3'
+  VERSION = '2.6.4'
 end


### PR DESCRIPTION
As the title says

It's going to be a little slower but I think it's acceptable

```
Comparison:
              before:  3125192.9 i/s
               after:  2903105.3 i/s - same-ish: difference falls within error
```